### PR TITLE
chore(golangci-lint): migrate config to version *2*

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -10,16 +11,11 @@ linters:
     - errcheck
     - errname
     - errorlint
-    - execinquery
     - exhaustive
-    - exportloopref
     - gocheckcompilerdirectives
     - gocritic
     - godot
-    - gofumpt
-    - goimports
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - loggercheck
@@ -34,32 +30,47 @@ linters:
     - reassign
     - revive
     - staticcheck
-    - tenv
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
     - usestdlibvars
     - wastedassign
     - whitespace
-
-linters-settings:
-  godot:
-    exclude:
-      - ^\s*.+:.+$
-      - ^\s*(?:=+|/+|-+|\++)
-  unparam:
-    check-exported: true
-
-issues:
-  exclude-rules:
-    # prevent lexerr on type assertions with field access
-    - linters:
-        - errorlint
-      source: \w\.\(\*?\w+\)\.\w+
-    - path: (?:_test|test_util)\.go$
-      linters:
-        - errcheck
-        - errorlint
-        - gosec
+  settings:
+    godot:
+      exclude:
+        - ^\s*.+:.+$
+        - ^\s*(?:=+|/+|-+|\++)
+    unparam:
+      check-exported: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errorlint
+        source: \w\.\(\*?\w+\)\.\w+
+      - linters:
+          - errcheck
+          - errorlint
+          - gosec
+        path: (?:_test|test_util)\.go$
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
this was done by simply running `golangci-lint migrate` as documented in the [migration][] guide

[migration]: https://golangci-lint.run/docs/product/migration-guide/